### PR TITLE
Modifications to Popper to enable hypothesis injection

### DIFF
--- a/popper/loop.py
+++ b/popper/loop.py
@@ -1639,7 +1639,7 @@ def get_bk_cons(settings: Settings, tester: Tester):
             signal.signal(signal.SIGALRM, handler)
             signal.alarm(settings.bkcons_timeout)
             try:
-                xs = deduce_bk_cons(settings, tester)
+                xs = deduce_bk_cons(settings)
             except TimeoutError as _exc:
                 settings.logger.debug(f'Loading bkcons FAILURE')
             finally:

--- a/popper/type_defs.py
+++ b/popper/type_defs.py
@@ -1,4 +1,4 @@
-from typing import FrozenSet, NamedTuple, Tuple
+from typing import FrozenSet, NamedTuple, Tuple, Literal as TypingLiteral
 from clingo import Symbol
 
 
@@ -9,3 +9,5 @@ class Literal(NamedTuple):
 
 Rule = Tuple[Literal, FrozenSet[Literal]]
 RuleBase = FrozenSet[Rule]
+
+Bit = TypingLiteral[0, 1]


### PR DESCRIPTION
Modify the way that Popper uses Clingo `SolveHandle`s and `SolveResults` to make it possible to insert assumptions into the running of the ASP for hypothesis injection (taking hypothesized rules, generated outside Popper, and "inject" them as if Popper had generated them itself, through ASP).

Previously, instead of using a `clingo.SolveHandle`, Popper only used the `clingo.Model`-producing iterator extracted from it.  Now Popper stores the `SolveHandle`, as well, in the `Generator`, so that more fine-grained interactions (e.g., unsat-core extraction) are available.

In the process did some software archaeology on `popper.bkcons`, adding type annotations as tools for understanding.